### PR TITLE
[chore] Auth 서버 설정 파일 프로필 분리 (Dev/Prod) 

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,29 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  # [운영 DB 설정] - 배포 시 환경 변수로 주입됨 (수정 금지)
+  datasource:
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  # [운영 Redis 설정] - 배포 시 환경 변수로 주입됨 (수정 금지)
+  data:
+    redis:
+      host: ${SPRING_DATA_REDIS_HOST}
+      port: ${SPRING_DATA_REDIS_PORT}
+      password: ${SPRING_DATA_REDIS_PASSWORD}
+      ssl:
+        enabled: ${SPRING_DATA_REDIS_SSL_ENABLED:true} # 기본값 true
+
+  # [JPA 설정] - 운영 환경 최적화
+  jpa:
+    hibernate:
+      ddl-auto: validate # 스키마 변경 금지
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,9 @@
+server:
+  port: 9000
+
 spring:
   application:
     name: auth
+
+  profiles:
+    active: dev # 기본 실행 시 application-dev.yml을 읽음 (로컬용)


### PR DESCRIPTION
## 🔍 What
- Auth 서버 설정을 환경별(dev/prod)로 분리하여 운영 배포 시 민감정보가 코드에 포함되지 않도록 정리했습니다.
- application.yml에는 공통 설정만 두고, dev/prod 설정은 각각 application-dev.yml / application-prod.yml로 분리했습니다.
- 로컬 전용 설정 파일(application-dev.yml)이 원격 저장소에 올라가지 않도록 .gitignore에 제외 규칙을 추가했습니다.

## 🧪 How to test
로컬(dev) 확인
- Auth 서버 실행 후 active profile이 dev로 동작하는지 확인합니다.
- (로컬 DB/Redis를 사용하는 경우) 로컬 환경에서 로그인/토큰 발급 등 Auth 관련 API가 정상 동작하는지 확인합니다.

운영(prod) 확인
- 컨테이너/배포 환경에서 SPRING_PROFILES_ACTIVE=prod로 실행되는지 확인합니다.
- DB/Redis 설정이 application-prod.yml에 하드코딩되어 있지 않고, 환경 변수(SPRING_DATASOURCE_URL/USERNAME/PASSWORD, SPRING_DATA_REDIS_*)로 주입되는지 확인합니다.

## 🔗 Issue
- Closes: #6

---
### ✅ 체크리스트
- [x] base가 develop으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Chore] Auth 서버 설정 파일 프로필 분리)
- [ ] 최소 1명의 리뷰를 받았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 프로덕션 환경 설정을 추가했습니다. 데이터베이스 및 캐시 연결이 배포 환경의 환경 변수를 통해 구성되며, 스키마 자동 변경을 방지하는 설정이 포함되어 있습니다.
  * 개발 환경을 기본 프로필로 설정했습니다.
  * 애플리케이션 서버 포트를 9000으로 구성했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->