### PR TITLE
[refactor] Auth 서비스 SecurityConfig 리팩토링 및 권한 분리

### DIFF
--- a/src/main/java/kr/gilmok/auth/global/config/SecurityConfig.java
+++ b/src/main/java/kr/gilmok/auth/global/config/SecurityConfig.java
@@ -27,7 +27,8 @@ public class SecurityConfig extends CommonSecurityConfig {
     protected void configureRequestMatchers(
             AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auth) {
         auth.requestMatchers("/auth/signup", "/auth/login", "/auth/reissue").permitAll()
-            .requestMatchers(HttpMethod.GET, "/actuator/prometheus", "/actuator/health").permitAll();
+            .requestMatchers(HttpMethod.GET, "/actuator/prometheus", "/actuator/health").permitAll()
+            .requestMatchers("/error").permitAll();  // 404 등 에러 응답 시 forward되는 경로
     }
 
     @Bean


### PR DESCRIPTION
## 🔍 What
- Auth `SecurityConfig`를 `CommonSecurityConfig` 상속 구조로 변경했습니다.
- CORS·CSRF·세션·예외처리·JWT 필터 등록 등 중복 보안 설정을 제거하고, Auth 전용 URL 권한(`configureRequestMatchers`)과 빈(`PasswordEncoder`, `AuthenticationManager`)만 두었습니다.
- 에러 응답을 위해 `/error`를 permitAll에 추가했습니다.

## 🧪 How to test
- Auth 서버(9000) 기동 후 Postman으로 `POST /auth/login` → 200 + 토큰 확인.
- 받은 accessToken으로 `Authorization: Bearer <token>` 넣고 존재하지 않는 경로(예: `/auth/me`) 호출 → 404 응답 확인 (이전엔 401이 나오던 케이스).
- 토큰 없이 동일 경로 호출 → 401 확인.

## 🔗 Issue
- Closes: #13 

---
### ✅ 체크리스트
- [x] base가 **develop**으로 설정되었나요?
- [x] 제목이 이슈 제목과 동일한가요? (예: [Feat] 로그인 기능)
- [x] 최소 1명의 리뷰를 받았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩터링**
  * 보안 설정 아키텍처를 재구성하여 인증 기능의 유지보수성을 향상했습니다. 공개 엔드포인트 관리가 더욱 효율적으로 처리되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->