### PR TITLE
[perf] BCrypt strength 10 → 8로 조정

### DIFF
--- a/src/main/java/kr/gilmok/auth/global/config/SecurityConfig.java
+++ b/src/main/java/kr/gilmok/auth/global/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig extends CommonSecurityConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder(10);
+        return new BCryptPasswordEncoder(8);
     }
 
     @Bean


### PR DESCRIPTION
- 로그인 해싱 성능 개선 (~100ms → ~25ms)
- 기존 비밀번호 검증은 영향 없음 (BCrypt 해시에 라운드 정보 포함)

issue는 닫지 않음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 인증 시스템 설정 최적화

---

**단어 수: 8자**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->